### PR TITLE
add daemontools-run as dependency, tinycdb as recommendation

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -40,6 +40,8 @@ Architecture: any
 Pre-Depends: adduser
 Depends: ${misc:Depends}
  , ${shlibs:Depends}
+ , daemontools-run
+Recommends: tinycdb
 Description: Sign email via milter protocol
  signing-milter  uses  the  milter  interface, originally distributed as
  part of version 8.11 of sendmail(8), to  provide  signing  service  for


### PR DESCRIPTION
without the dependency on `daemontools-run` the package installation fails with an error 