### PR TITLE
new option -M for magic path declaration (replacing the signingtable)

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,9 @@
+20230225
+ Adding magic path option '-M' to provide a magic path
+ under which all key files are stored within files
+ named by sender-address followed by '.pem', i.e.
+ lonesome_cowboy@anywhere.de.pem
+
 202302xx
  Fix .f https://github.com/andreasschulze/signing-milter/issues/3
  socketmode may be relaxed with '-c :relax'

--- a/callbacks.c
+++ b/callbacks.c
@@ -82,6 +82,24 @@ sfsistat callback_envfrom(SMFICTX* ctx, char** argv) {
     warn_if_dict_changed(&dict_signingtable);
 
     pemfilename = dict_lookup(&dict_signingtable, argv[0]);
+
+    /*
+     * MagicPath
+     */
+    char longpemfilename[1024];
+extern char* opt_magicpath;
+if (opt_magicpath) {
+    longpemfilename[0] = 0;
+    strcpy(longpemfilename, opt_magicpath);
+    strcat(longpemfilename, argv[0]);
+    strcat(longpemfilename, ".pem");
+    pemfilename = longpemfilename;
+    logmsg(LOG_INFO, "MagicPath filename '%s'", pemfilename);
+}
+    /*
+     * end-of-MagicPath
+     */
+
     if (pemfilename == NULL || *pemfilename == '\0') {
         /*
          * Absender nicht in der Signingtable gefunden.

--- a/main.c
+++ b/main.c
@@ -35,6 +35,13 @@ int   opt_timeout      = 600;
 char* opt_user         = "signing-milter";
 int   opt_addxheader   = 0;
 int   opt_signerfromheader = 0;
+/*
+ * MagicPath
+ */
+char* opt_magicpath    = NULL;
+/*
+ * end-of-MagicPath
+ */
 
 /* globale Variablen */
 struct DICT dict_signingtable = {
@@ -77,7 +84,8 @@ int main(int argc, char** argv) {
      */
     uid = gid = client_gid = root_gid = 0;
 
-    while ((c = getopt(argc, argv, "bc:d:hfg:k:lm:n:s:t:u:vx")) > 0) {
+    while ((c = getopt(argc, argv, "bc:d:hfg:k:lm:n:s:t:u:vxM:")) > 0) {
+
         switch (c) {
         case 'b': /* break contentheader */
             logmsg(LOG_INFO, "option -b is ignored for compatibily reasons, you may remove it safely");
@@ -168,6 +176,16 @@ int main(int argc, char** argv) {
         case 'x': /* add X-Header */
             opt_addxheader = (int) !opt_addxheader;
             break;
+/*
+ * MagicPath
+ */
+        case 'M': /* magic-path */
+            opt_magicpath = optarg;
+            logmsg(LOG_ERR, "magic path (%s) activated", opt_magicpath);
+            break;
+/*
+ * end-of-MagicPath
+ */
         default:
             usage();
             exit(EX_USAGE);


### PR DESCRIPTION
Having to deal with volatile number of users with certificates, the storage of the certificate is enough to sign the passed message (w/o dealing with a signingtable).
The passed magic-path points to a directory with different certificates in it, like:
gnats@h-ka.de.pem  root@h-ka.de.pem  daniel@h-ka.de.pem 